### PR TITLE
Refactor process_check

### DIFF
--- a/lib/ex_health.ex
+++ b/lib/ex_health.ex
@@ -110,22 +110,14 @@ defmodule ExHealth do
 
     quote do
       def unquote(function_name)() do
-        case Process.whereis(unquote(module)) do
-          nil ->
-            {:error, "no proc"}
-
-          pid ->
-            case Process.info(pid) do
-              nil ->
-                {:error, "no proc"}
-
-              info ->
-                case Keyword.fetch(info, :status) do
-                  {:ok, :running} -> :ok
-                  {:ok, :waiting} -> :ok
-                  _ -> {:error, "process not running/waiting"}
-                end
-            end
+        with pid <- Process.whereis(unquote(module)),
+             info <- Process.info(pid),
+             {:ok, status} <- Keyword.fetch(info, :status),
+             status == :running || :waiting do
+          :ok
+        else
+          nil -> {:error, "no proc"}
+          _ -> {:error, "process not running/waiting"}
         end
       end
     end

--- a/lib/ex_health.ex
+++ b/lib/ex_health.ex
@@ -91,7 +91,7 @@ defmodule ExHealth do
   @doc """
   Defines a healthcheck function for a given process.
 
-  Returns true if the process has one of the following statuses:
+  Returns `:ok` if the process has one of the following statuses:
     - `:running`
     - `:waiting`
 


### PR DESCRIPTION
As I was writing some POC code to extend `ex_health`, I ran [credo](https://github.com/rrrene/credo) against it. Credo dinged you for some (IMO) small stuff and a legitimate refactor opportunity:
```
┃ [F] → Function body is nested too deep (max depth is 2, was 3).
┃       lib/ex_health.ex:123:17 #(ExHealth.process_check.)
┃ [F] → Function body is nested too deep (max depth is 2, was 3).
┃       lib/ex_health.ex:123:17 #(ExHealth.process_check.)
```

This PR addresses that credo refactor by using `with` to remove the nested `case` statements in the `process_check` macro. 

Since I was touching the macro anyway, I also changed to doc to more accurately reflect the function return value.